### PR TITLE
Refactor: move BoardWrapper component to BoardPage

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "idb": "^7.1.1",
     "react-beautiful-dnd": "^13.1.1",
     "react-error-boundary": "^4.0.3",
+    "react-hook-form": "^7.43.9",
     "react-modal": "^3.16.1",
     "react-redux": "^8.0.5",
     "react-router-dom": "^6.8.2",

--- a/src/components/Board/index.tsx
+++ b/src/components/Board/index.tsx
@@ -1,7 +1,4 @@
-import { Suspense } from "react";
 import { DragDropContext, Droppable } from "react-beautiful-dnd";
-import { QueryErrorResetBoundary } from "@tanstack/react-query";
-import { ErrorBoundary } from "react-error-boundary";
 import {
   useCardsQuery,
   useEditCardPositionMutation,
@@ -12,12 +9,10 @@ import {
 import { AddListRequest, DeleteListRequest, EditListRequest } from "@/queries/cards/interface";
 import CardList from "@components/CardList";
 import CardListComposer from "@components/CardListComposer";
-import BoardSkeleton from "@components/skeletons/BoardSkeleton";
-import EmptyBoard from "@components/EmptyBoard";
 
 import * as S from "./style";
 
-const BoardContent = () => {
+const Board = () => {
   const { data: cardLists } = useCardsQuery();
   const { mutate: addListMutate } = useAddListMutation();
   const { mutate: deleteListMutate } = useDeleteListMutation();
@@ -82,22 +77,5 @@ const BoardContent = () => {
     </S.Container>
   );
 };
-
-function Board() {
-  return (
-    <QueryErrorResetBoundary>
-      {({ reset }) => (
-        <ErrorBoundary
-          onReset={reset}
-          fallbackRender={({ resetErrorBoundary }) => <EmptyBoard onQueryErrorReset={resetErrorBoundary} />}
-        >
-          <Suspense fallback={<BoardSkeleton />}>
-            <BoardContent />
-          </Suspense>
-        </ErrorBoundary>
-      )}
-    </QueryErrorResetBoundary>
-  );
-}
 
 export default Board;

--- a/src/pages/BoardPage/index.tsx
+++ b/src/pages/BoardPage/index.tsx
@@ -1,10 +1,15 @@
-import React, { useState } from "react";
+import React, { useState, Suspense } from "react";
+import { QueryErrorResetBoundary } from "@tanstack/react-query";
+import { ErrorBoundary } from "react-error-boundary";
 import { Layout } from "antd";
 import Sider from "@components/Sider";
 import Drawer from "@components/Drawer";
 import Header from "@components/Header";
 import Menu from "@components/Menu";
 import Board from "@components/Board";
+import BoardSkeleton from "@components/skeletons/BoardSkeleton";
+import EmptyBoard from "@components/EmptyBoard";
+
 import * as S from "./style";
 
 const { Content } = Layout;
@@ -27,7 +32,7 @@ const BoardPage: React.FC = () => {
         <Sider />
         <Content style={S.Content}>
           <Menu showDrawer={showDrawer} boardName={"boardName"} />
-          <Board />
+          <BoardWrapper />
           <Drawer open={open} onClose={onClose} />
         </Content>
       </Layout>
@@ -36,3 +41,20 @@ const BoardPage: React.FC = () => {
 };
 
 export default BoardPage;
+
+function BoardWrapper() {
+  return (
+    <QueryErrorResetBoundary>
+      {({ reset }) => (
+        <ErrorBoundary
+          onReset={reset}
+          fallbackRender={({ resetErrorBoundary }) => <EmptyBoard onQueryErrorReset={resetErrorBoundary} />}
+        >
+          <Suspense fallback={<BoardSkeleton />}>
+            <Board />
+          </Suspense>
+        </ErrorBoundary>
+      )}
+    </QueryErrorResetBoundary>
+  );
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -14980,6 +14980,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"react-hook-form@npm:^7.43.9":
+  version: 7.43.9
+  resolution: "react-hook-form@npm:7.43.9"
+  peerDependencies:
+    react: ^16.8.0 || ^17 || ^18
+  checksum: 65b94de625f2b7921c4e856bf0abbe142bfe06c052217bd1bcc3a842e2cc37fa3a3e03758119dc038bbcf5edb49e02c29206528b80b201f9a4d601471ef78153
+  languageName: node
+  linkType: hard
+
 "react-inspector@npm:^5.1.0":
   version: 5.1.1
   resolution: "react-inspector@npm:5.1.1"
@@ -17197,6 +17206,7 @@ __metadata:
     msw: ^1.1.0
     react-beautiful-dnd: ^13.1.1
     react-error-boundary: ^4.0.3
+    react-hook-form: ^7.43.9
     react-modal: ^3.16.1
     react-redux: ^8.0.5
     react-router-dom: ^6.8.2


### PR DESCRIPTION
### Description
- Suspense 랩핑 컴포넌트 선언 위치 변경

### Problem
- QueryErrorResetBoundary, ErrorBoundary, Suspenses로 감싼 Board 컴포넌트를 페이지에 렌더링할 때 뎁스가 깊어지는 문제
- Board => BoardContent로 바꾸고 랩핑 컴포넌트를 Board로 만들어 import해 사용했으나, 
- 불필요한 네이밍 변경 및 사용하는 페이지 컴포넌트에서 랩핑 여부를 알 수 없다는 단점이 있음

### Solution
- BoardPage에서 Board컴포넌트를 렌더링할 때 랩핑 컴포넌트를 선언해 사용