### PR TITLE
Feat/refactor dnd

### DIFF
--- a/src/components/Board/index.tsx
+++ b/src/components/Board/index.tsx
@@ -47,17 +47,10 @@ const Board = ({searchKeyword}:Props) => {
     }
     editCardPositionMutate({
       cardId: draggableId,
-      destination: {
-        listId: destination.droppableId,
-        index: destination.index
-      },
-      source: {
-        listId: source.droppableId,
-        index: source.index
-      }
-    })
-  }
-
+      listId: destination.droppableId,
+      index: destination.index,
+    });
+  };
   return (
     <S.Container>
       <DragDropContext onDragEnd={handleDragEnd}>
@@ -80,7 +73,7 @@ const Board = ({searchKeyword}:Props) => {
         <CardListComposer onAddList={handleAddList} />
       </DragDropContext>
     </S.Container>
-  )
-}
+  );
+};
 
-export default Board
+export default Board;

--- a/src/components/Card/index.stories.tsx
+++ b/src/components/Card/index.stories.tsx
@@ -16,7 +16,7 @@ export default {
 const Template = (args: CardProps) => {
   return (
     <Provider store={store}>
-      <Card data={{ id: "cardId", description: "default" }} onEditCard={() => {}} onDeleteCard={() => {}} />
+      <Card data={{ id: "cardId", description: "default", index: 0 }} onEditCard={() => {}} onDeleteCard={() => {}} />
     </Provider>
   );
 };

--- a/src/components/CardEditor/index.stories.tsx
+++ b/src/components/CardEditor/index.stories.tsx
@@ -7,7 +7,7 @@ export default {
 };
 
 const Template = () => {
-  const data = { id: "id", description: "description" };
+  const data = { id: "id", description: "description", index: 0 };
   const onCardEditorClose = () => {};
   const setCardEditorOpened = () => {};
   const onEditCard = () => {};

--- a/src/components/CardList/index.stories.tsx
+++ b/src/components/CardList/index.stories.tsx
@@ -20,6 +20,7 @@ const Template = (args: { text: string }) => {
             {
               id: "string",
               description: "string",
+              index: 0,
             },
           ],
         }}

--- a/src/interfaces/cards.ts
+++ b/src/interfaces/cards.ts
@@ -1,6 +1,7 @@
 export interface ICard {
   id: string;
   description: string;
+  index: number;
 }
 
 export interface ICardList {

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -23,18 +23,16 @@ const queryClient = new QueryClient();
 ReactModal.setAppElement("#root");
 
 ReactDOM.createRoot(document.getElementById("root") as HTMLElement).render(
-  <React.StrictMode>
-    <QueryClientProvider client={queryClient}>
-      <ReactQueryDevtools initialIsOpen={false} />
-      <Provider store={store}>
-        <ThemeProvider theme={theme}>
-          <ModalsProvider>
-            <GlobalStyle />
-            <App />
-            <ToastContainer position="bottom-left" theme="dark" autoClose={1500} hideProgressBar={true} limit={1} />
-          </ModalsProvider>
-        </ThemeProvider>
-      </Provider>
-    </QueryClientProvider>
-  </React.StrictMode>,
+  <QueryClientProvider client={queryClient}>
+    <ReactQueryDevtools initialIsOpen={false} />
+    <Provider store={store}>
+      <ThemeProvider theme={theme}>
+        <ModalsProvider>
+          <GlobalStyle />
+          <App />
+          <ToastContainer position="bottom-left" theme="dark" autoClose={1500} hideProgressBar={true} limit={1} />
+        </ModalsProvider>
+      </ThemeProvider>
+    </Provider>
+  </QueryClientProvider>,
 );

--- a/src/mocks/dbfunctions.ts
+++ b/src/mocks/dbfunctions.ts
@@ -116,15 +116,19 @@ export const getCardIdsByListId = async (listId: string): Promise<CardData[]> =>
   return cards
 }
 
-export const addCard = async (card: Omit<CardData, 'index'>) => {
-  const db = await initDb()
-  const tx = db.transaction(cardStoreName, 'readwrite')
-  const store = tx.objectStore(cardStoreName)
-  const index = await store.count()
-  await store.add({ ...card, index })
-  await tx.done
-  return card
-}
+export const addCard = async (card: Omit<CardData, "index">) => {
+  const db = await initDb();
+  const tx = db.transaction([cardStoreName, listStoreName], "readwrite");
+
+  const store = tx.objectStore(cardStoreName);
+  const listStore = tx.objectStore(listStoreName);
+  const list = await (await store.getAll()).filter((listCard) => listCard.listId === card.listId);
+  console.log(list, "list");
+  const index = list.length;
+  await store.add({ ...card, index });
+  await tx.done;
+  return card;
+};
 
 export const editCard = async ({ id, description }: EditCardData) => {
   const db = await initDb();
@@ -142,20 +146,30 @@ export const editCardPosition = async ({ cardId, listId, index }: EditCardPositi
 
   const tx = db.transaction([cardStoreName, listStoreName], "readwrite");
   const cardStore = tx.objectStore(cardStoreName);
-  const listStore = tx.objectStore(listStoreName);
-  const card = await cardStore.get(cardId);
-  const list = await listStore.get(listId);
 
-  card.listId = listId;
+  const movedCard = await cardStore.get(cardId);
 
-  // Update the card in the cardStore
-  await cardStore.put(card);
+  const oldCardList = await (await cardStore.getAll()).filter((card) => card.listId === movedCard.listId);
 
-  const oldIndex = card.index;
-  const newIndex = index;
-  const cards = await (await cardStore.getAll()).filter((card) => card.listId === listId);
-  // Fix: change index
-  console.log(cards);
+  oldCardList.forEach(async (card) => {
+    if (card.index > movedCard.index) {
+      card.index--;
+      await cardStore.put(card);
+    }
+  });
+
+  const newCardList = await (await cardStore.getAll()).filter((card) => card.listId === listId);
+  newCardList.forEach(async (card) => {
+    if (card.index >= index) {
+      card.index++;
+      await cardStore.put(card);
+    }
+  });
+
+  movedCard.listId = listId;
+  movedCard.index = index;
+
+  await cardStore.put(movedCard);
 };
 
 export const deleteCard = async ({ id }: DeleteCardData) => {

--- a/src/mocks/dbfunctions.ts
+++ b/src/mocks/dbfunctions.ts
@@ -1,4 +1,4 @@
-import { type EditCardPositionParam, type EditCardPositionRequest } from './../queries/cards/interface'
+import { type EditCardPositionRequest } from './../queries/cards/interface'
 import { openDB } from 'idb'
 
 export interface CardListData {
@@ -141,7 +141,7 @@ export const editCard = async ({ id, description }: EditCardData) => {
   return card;
 };
 
-export const editCardPosition = async ({ cardId, listId, index }: EditCardPositionParam & EditCardPositionRequest) => {
+export const editCardPosition = async ({ cardId, listId, index }: EditCardPositionRequest) => {
   const db = await initDb();
 
   const tx = db.transaction([cardStoreName, listStoreName], "readwrite");

--- a/src/mocks/handlers/cards.ts
+++ b/src/mocks/handlers/cards.ts
@@ -1,4 +1,4 @@
-import { type EditCardPositionRequest } from "../../queries/cards/interface";
+import { EditCardPositionParam, type EditCardPositionRequest } from "../../queries/cards/interface";
 import {
   type AddCardRequest,
   type AddListRequest,
@@ -126,19 +126,18 @@ export const cardsHandlers = [
       );
   }),
 
-  rest.put<EditCardPositionRequest>("/cards/:cardId/move", async(req, res, ctx) => {
-    const { cardId } = req.params as { cardId: string };
-    const { destination, source } = req.body ;
-    const error = handleAuthError(req, res, ctx);
-    if (error != null) return await error;
+  rest.put<string, EditCardPositionParam>("/cards/:cardId/move", (req, res, ctx) => {
+    const { cardId } = req.params;
+    const { listId, index } = JSON.parse(req.body) as EditCardPositionRequest;
 
-     await editCardPosition({ cardId, destination, source })
-      return await res(
+    return editCardPosition({ cardId, listId, index }).then(() => {
+      return res(
         ctx.status(200),
         ctx.json({
           message: "Card position updated",
         }),
       );
+    })
   }),
 
   rest.delete<DeleteListRequest>("/lists", async(req, res, ctx) => {

--- a/src/queries/cards/index.ts
+++ b/src/queries/cards/index.ts
@@ -107,11 +107,12 @@ export const useEditListMutation = () => {
 export const useEditCardPositionMutation = () => {
   const queryClient = useQueryClient();
   return useMutation<I.ResponseMessage, AxiosError, I.EditCardPositionRequest, I.EditCardMutationData>(
-    ({ cardId, listId, index }: I.EditCardPositionParam & I.EditCardPositionRequest) => {
+    ({ cardId, listId, index }: I.EditCardPositionRequest) => {
       return request.put<I.ResponseMessage>({
         path: `/cards/${cardId}/move`,
         isMock: true,
         params: { listId, index },
+        shouldAuthorize: true,
       });
     },
     {

--- a/src/queries/cards/index.ts
+++ b/src/queries/cards/index.ts
@@ -11,7 +11,7 @@ const cardListsKeys = {
 
 export const useCardsQuery = ({ search }: I.GetCardRequest) => {
   return useQuery(
-    cardListsKeys.search(search),
+    cardListsKeys.all,
     async () => {
       return await request.get<I.GetCardListsResponse[]>({
         path: "/cards",

--- a/src/queries/cards/index.ts
+++ b/src/queries/cards/index.ts
@@ -1,6 +1,7 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { request } from "@/utils/httpRequest";
 import type * as I from "./interface";
+import { ICardList } from "@/interfaces/cards";
 
 const cardListsKeys = {
   all: ["cardLists"] as const,
@@ -105,7 +106,7 @@ export const useEditListMutation = () => {
 export const useEditCardPositionMutation = () => {
   const queryClient = useQueryClient();
   return useMutation(
-    ({ cardId, listId, index }: I.EditCardPositionParam & EditCardPositionRequest) => {
+    ({ cardId, listId, index }: I.EditCardPositionParam & I.EditCardPositionRequest) => {
       return request.put<I.ResponseMessage>({
         path: `/cards/${cardId}/move`,
         isMock: true,
@@ -113,8 +114,35 @@ export const useEditCardPositionMutation = () => {
       });
     },
     {
-      onSuccess: async () => {
-        await queryClient.invalidateQueries(cardListsKeys.all);
+      onSuccess: () => queryClient.invalidateQueries(cardListsKeys.all),
+      onMutate: ({ cardId, listId, index }) => {
+        const previousData = queryClient.getQueryData<ICardList[]>(cardListsKeys.all);
+        if (!previousData) return;
+
+        const previousList = previousData.filter((list) => list.cards.some((card) => card.id === cardId));
+        const previousListId = previousList[0].id;
+        const card = previousList[0].cards.filter((card) => card.id === cardId)[0];
+
+        const updatedData = previousData.map((list) => {
+          if (list.id === listId) {
+            const newCards = Array.from(list.cards);
+            newCards.splice(index, 0, card);
+            return { ...list, cards: newCards };
+          } else if (list.id === previousListId) {
+            const newCards = Array.from(list.cards);
+            newCards.splice(card.index, 1);
+            return { ...list, cards: newCards };
+          } else {
+            return list;
+          }
+        });
+
+        queryClient.setQueryData(cardListsKeys.all, updatedData);
+
+        return () => queryClient.setQueryData(cardListsKeys.all, previousData);
+      },
+      onError: (error, variables, rollback) => {
+        rollback?.();
       },
     },
   );

--- a/src/queries/cards/index.ts
+++ b/src/queries/cards/index.ts
@@ -105,12 +105,11 @@ export const useEditListMutation = () => {
 export const useEditCardPositionMutation = () => {
   const queryClient = useQueryClient();
   return useMutation(
-    async ({ cardId, destination, source }: I.EditCardPositionParam & I.EditCardPositionRequest) => {
-      return await request.put<I.ResponseMessage>({
+    ({ cardId, listId, index }: I.EditCardPositionParam & EditCardPositionRequest) => {
+      return request.put<I.ResponseMessage>({
         path: `/cards/${cardId}/move`,
-        params: { destination, source },
         isMock: true,
-        shouldAuthorize: true,
+        params: { listId, index },
       });
     },
     {

--- a/src/queries/cards/interface.ts
+++ b/src/queries/cards/interface.ts
@@ -22,14 +22,9 @@ export interface EditCardRequest {
 }
 
 export interface EditCardPositionRequest {
-  destination: {
-    listId: string;
-    index: number;
-  };
-  source: {
-    listId: string;
-    index: number;
-  };
+  cardId: string;
+  listId: string;
+  index: number;
 }
 
 export interface EditCardPositionParam {

--- a/src/queries/cards/interface.ts
+++ b/src/queries/cards/interface.ts
@@ -8,6 +8,7 @@ export interface GetCardListsResponse {
   cards: Array<{
     id: string;
     description: string;
+    index: number;
   }>;
 }
 

--- a/src/queries/cards/interface.ts
+++ b/src/queries/cards/interface.ts
@@ -1,3 +1,5 @@
+import { ICardList } from "@/interfaces/cards";
+
 export interface GetCardRequest {
   search: string;
 }
@@ -26,6 +28,10 @@ export interface EditCardPositionRequest {
   cardId: string;
   listId: string;
   index: number;
+}
+
+export interface EditCardMutationData {
+  currentCards: ICardList[];
 }
 
 export interface EditCardPositionParam {

--- a/src/queries/cards/interface.ts
+++ b/src/queries/cards/interface.ts
@@ -34,10 +34,6 @@ export interface EditCardMutationData {
   currentCards: ICardList[];
 }
 
-export interface EditCardPositionParam {
-  cardId: string;
-}
-
 export interface DeleteCardRequest {
   id: string;
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -15647,6 +15647,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"react-hook-form@npm:^7.43.9":
+  version: 7.43.9
+  resolution: "react-hook-form@npm:7.43.9"
+  peerDependencies:
+    react: ^16.8.0 || ^17 || ^18
+  checksum: 65b94de625f2b7921c4e856bf0abbe142bfe06c052217bd1bcc3a842e2cc37fa3a3e03758119dc038bbcf5edb49e02c29206528b80b201f9a4d601471ef78153
+  languageName: node
+  linkType: hard
+
 "react-inspector@npm:^5.1.0":
   version: 5.1.1
   resolution: "react-inspector@npm:5.1.1"


### PR DESCRIPTION
### Description

- 드래그앤 드롭 시 끊기는 현상 수정
- 요청 형태 수정: source, destination 대신 cardId, listId, index로 요청하도록 리팩토링

### Problem
- drag and drop 시 옮긴 카드가 원래 자리로 돌아갔다가 새로운 자리로 이동하는 현상
- api요청이 완료된 후 새로 업데이트 된 데이터를 불러와 새로 렌더링하기 전에 onDragEnd함수가 종료되어 기존 자리로 돌아가는 것이 원인


https://user-images.githubusercontent.com/67543454/234274838-dc99de5f-2be0-4728-8ede-f3b2fb1b9b2d.mov




### Solution
- react-query의 optimistic update 사용
- 데이터 요청 전 미리 요청이 성공할 것을 전제로 상태를 업데이트 (setQueryData)
- 만약 데이터 요청이 실패할 경우 기존 데이터로 되돌려놓도록 onError 처리


https://user-images.githubusercontent.com/67543454/233841937-c4c80bf2-31f7-4487-a7d7-c245fa3608dc.mov


### Question
- search 기능을 위해 쿼리키를 분리했으나, onMutate에서 all 키를 사용해 원하는 대로 카드 캐시 데이터를 가져올 수 없습니다. (현재는 모두 all을 쿼리키로 사용)
