### PR TITLE
Refactor: generic types in api request function

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -25,6 +25,7 @@
     "n/handle-callback-err": "off",
     "no-multiple-empty-lines": "error",
     "@typescript-eslint/no-confusing-void-expression": "off",
+    "@typescript-eslint/return-await": "off",
     "@typescript-eslint/no-floating-promises": "off",
     "@typescript-eslint/promise-function-async": "off",
     "@typescript-eslint/consistent-type-imports": "off",

--- a/src/interfaces/httpRequest.ts
+++ b/src/interfaces/httpRequest.ts
@@ -1,8 +1,8 @@
-export interface RequestParams<TQueryParams = Params, TParams = any> {
+export interface RequestParams<TParams = Params> {
   path: string;
   method?: RequestMethod;
   params?: TParams;
-  queryParams?: TQueryParams;
+  queryParams?: TParams;
   isMock?: boolean;
   shouldAuthorize?: boolean;
 }

--- a/src/pages/LoginPage/index.tsx
+++ b/src/pages/LoginPage/index.tsx
@@ -15,7 +15,7 @@ const LoginPage: React.FC = () => {
 
   const handleSubmitClick = async () => {
     const res = await handleLogin();
-    handleLoginComplete(res.accessToken);
+    handleLoginComplete(res?.accessToken);
   };
 
   const handleLogin = async () => {

--- a/src/queries/auth/index.ts
+++ b/src/queries/auth/index.ts
@@ -3,7 +3,7 @@ import { request } from "@utils/httpRequest";
 import { LoginRequest, LoginResponse } from "./interface";
 
 export const useLoginMutation = () => {
-  return useMutation(async (params: LoginRequest) => {
-    return await request.post<LoginResponse>({ path: "/login", isMock: true, params });
+  return useMutation((params: LoginRequest) => {
+    return request.post<LoginRequest, LoginResponse>({ path: "/login", isMock: true, params });
   });
 };

--- a/src/queries/cards/index.ts
+++ b/src/queries/cards/index.ts
@@ -24,7 +24,11 @@ export const useCardsQuery = ({ search }: I.GetCardRequest) => {
   return useQuery(
     cardListsKeys.search(search),
     () => {
-      return request.get<I.GetCardListsResponse[]>(parameter);
+      return request.get<I.GetCardRequest, null, I.GetCardListsResponse[]>({
+        path: "/cards",
+        queryParams: { search },
+        isMock: true,
+      });
     },
     {
       suspense: true,
@@ -36,7 +40,7 @@ export const useAddCardMutation = () => {
   const queryClient = useQueryClient();
   return useMutation(
     (params: I.AddCardRequest) => {
-      return request.post<I.ResponseMessage>({
+      return request.post<null, I.AddCardRequest, I.ResponseMessage>({
         path: "/cards",
         params,
         isMock: true,
@@ -53,7 +57,12 @@ export const useEditCardMutation = () => {
   const queryClient = useQueryClient();
   return useMutation(
     (params: I.EditCardRequest) => {
-      return request.put<I.ResponseMessage>({ path: "/cards", params, isMock: true, shouldAuthorize: true });
+      return request.put<null, I.EditCardRequest, I.ResponseMessage>({
+        path: "/cards",
+        params,
+        isMock: true,
+        shouldAuthorize: true,
+      });
     },
     {
       onSuccess: () => queryClient.invalidateQueries(cardListsKeys.all),
@@ -65,7 +74,12 @@ export const useDeleteCardMutation = () => {
   const queryClient = useQueryClient();
   return useMutation(
     (params: I.DeleteCardRequest) => {
-      return request.delete<I.ResponseMessage>({ path: "/cards", params, isMock: true, shouldAuthorize: true });
+      return request.delete<null, I.DeleteCardRequest, I.ResponseMessage>({
+        path: "/cards",
+        params,
+        isMock: true,
+        shouldAuthorize: true,
+      });
     },
     {
       onSuccess: () => queryClient.invalidateQueries(cardListsKeys.all),
@@ -77,7 +91,7 @@ export const useAddListMutation = () => {
   const queryClient = useQueryClient();
   return useMutation(
     (params: I.AddListRequest) => {
-      return request.post<I.ResponseMessage>({
+      return request.post<null, I.AddListRequest, I.ResponseMessage>({
         path: "/lists",
         params,
         isMock: true,
@@ -94,7 +108,12 @@ export const useEditListMutation = () => {
   const queryClient = useQueryClient();
   return useMutation(
     (params: I.EditListRequest) => {
-      return request.put<I.ResponseMessage>({ path: "/lists", params, isMock: true, shouldAuthorize: true });
+      return request.put<null, I.EditListRequest, I.ResponseMessage>({
+        path: "/lists",
+        params,
+        isMock: true,
+        shouldAuthorize: true,
+      });
     },
     {
       onSuccess: () => queryClient.invalidateQueries(cardListsKeys.all),
@@ -106,7 +125,7 @@ export const useEditCardPositionMutation = () => {
   const [searchParams] = useSearchParams(window.location.search);
   return useMutation<I.ResponseMessage, AxiosError, I.EditCardPositionRequest, I.EditCardMutationData>(
     ({ cardId, listId, index }: I.EditCardPositionRequest) => {
-      return request.put<I.ResponseMessage>({
+      return request.put<null, Omit<I.EditCardPositionRequest, "cardId">, I.ResponseMessage>({
         path: `/cards/${cardId}/move`,
         isMock: true,
         params: { listId, index },
@@ -138,7 +157,12 @@ export const useDeleteListMutation = () => {
   const queryClient = useQueryClient();
   return useMutation(
     (params: I.DeleteListRequest) => {
-      return request.delete<I.ResponseMessage>({ path: "/lists", params, isMock: true, shouldAuthorize: true });
+      return request.delete<null, I.DeleteListRequest, I.ResponseMessage>({
+        path: "/lists",
+        params,
+        isMock: true,
+        shouldAuthorize: true,
+      });
     },
     {
       onSuccess: () => queryClient.invalidateQueries(cardListsKeys.all),

--- a/src/queries/cards/index.ts
+++ b/src/queries/cards/index.ts
@@ -24,7 +24,7 @@ export const useCardsQuery = ({ search }: I.GetCardRequest) => {
   return useQuery(
     cardListsKeys.search(search),
     () => {
-      return request.get<I.GetCardRequest, null, I.GetCardListsResponse[]>({
+      return request.get<I.GetCardRequest, I.GetCardListsResponse[]>({
         path: "/cards",
         queryParams: { search },
         isMock: true,
@@ -40,7 +40,7 @@ export const useAddCardMutation = () => {
   const queryClient = useQueryClient();
   return useMutation(
     (params: I.AddCardRequest) => {
-      return request.post<null, I.AddCardRequest, I.ResponseMessage>({
+      return request.post<I.AddCardRequest, I.ResponseMessage>({
         path: "/cards",
         params,
         isMock: true,
@@ -57,7 +57,7 @@ export const useEditCardMutation = () => {
   const queryClient = useQueryClient();
   return useMutation(
     (params: I.EditCardRequest) => {
-      return request.put<null, I.EditCardRequest, I.ResponseMessage>({
+      return request.put<I.EditCardRequest, I.ResponseMessage>({
         path: "/cards",
         params,
         isMock: true,
@@ -74,7 +74,7 @@ export const useDeleteCardMutation = () => {
   const queryClient = useQueryClient();
   return useMutation(
     (params: I.DeleteCardRequest) => {
-      return request.delete<null, I.DeleteCardRequest, I.ResponseMessage>({
+      return request.delete<I.DeleteCardRequest, I.ResponseMessage>({
         path: "/cards",
         params,
         isMock: true,
@@ -91,7 +91,7 @@ export const useAddListMutation = () => {
   const queryClient = useQueryClient();
   return useMutation(
     (params: I.AddListRequest) => {
-      return request.post<null, I.AddListRequest, I.ResponseMessage>({
+      return request.post<I.AddListRequest, I.ResponseMessage>({
         path: "/lists",
         params,
         isMock: true,
@@ -108,7 +108,7 @@ export const useEditListMutation = () => {
   const queryClient = useQueryClient();
   return useMutation(
     (params: I.EditListRequest) => {
-      return request.put<null, I.EditListRequest, I.ResponseMessage>({
+      return request.put<I.EditListRequest, I.ResponseMessage>({
         path: "/lists",
         params,
         isMock: true,
@@ -125,7 +125,7 @@ export const useEditCardPositionMutation = () => {
   const [searchParams] = useSearchParams(window.location.search);
   return useMutation<I.ResponseMessage, AxiosError, I.EditCardPositionRequest, I.EditCardMutationData>(
     ({ cardId, listId, index }: I.EditCardPositionRequest) => {
-      return request.put<null, Omit<I.EditCardPositionRequest, "cardId">, I.ResponseMessage>({
+      return request.put<Omit<I.EditCardPositionRequest, "cardId">, I.ResponseMessage>({
         path: `/cards/${cardId}/move`,
         isMock: true,
         params: { listId, index },
@@ -157,7 +157,7 @@ export const useDeleteListMutation = () => {
   const queryClient = useQueryClient();
   return useMutation(
     (params: I.DeleteListRequest) => {
-      return request.delete<null, I.DeleteListRequest, I.ResponseMessage>({
+      return request.delete<I.DeleteListRequest, I.ResponseMessage>({
         path: "/lists",
         params,
         isMock: true,

--- a/src/utils/httpRequest.ts
+++ b/src/utils/httpRequest.ts
@@ -5,14 +5,14 @@ const headers: HeadersInit = {
   "Content-Type": "application/json; charset=utf-8",
 };
 
-const fetchRequest = async <TQueryParams>({
+const fetchRequest = async <TQueryParams, TParams>({
   path,
   method,
   queryParams,
   params,
   isMock,
   shouldAuthorize,
-}: RequestParams<TQueryParams>) => {
+}: RequestParams<TQueryParams, TParams>) => {
   const convertedParams = queryParams
     ? Object.entries(queryParams).reduce((newObj: Record<string, string>, [key, value]) => {
         newObj[key] = value.toString();
@@ -46,19 +46,19 @@ const fetchRequest = async <TQueryParams>({
 
 const handleRequest = (option?: { isMock: true }) => {
   return {
-    async get<TResponse>(params: RequestParams): Promise<TResponse> {
-      return await fetchRequest({ ...params, method: "get", ...option });
+    async get<TQueryParams, TParams, TResponse>(params: RequestParams<TQueryParams, TParams>): Promise<TResponse> {
+      return await fetchRequest<TQueryParams, TParams>({ ...params, method: "get", ...option });
     },
 
-    async post<TResponse>(params: RequestParams): Promise<TResponse> {
+    async post<TQueryParams, TParams, TResponse>(params: RequestParams<TQueryParams, TParams>): Promise<TResponse> {
       return await fetchRequest({ ...params, method: "post", ...option });
     },
 
-    async put<TResponse>(params: RequestParams): Promise<TResponse> {
+    async put<TQueryParams, TParams, TResponse>(params: RequestParams<TQueryParams, TParams>): Promise<TResponse> {
       return await fetchRequest({ ...params, method: "put", ...option });
     },
 
-    async delete<TResponse>(params: RequestParams): Promise<TResponse> {
+    async delete<TQueryParams, TParams, TResponse>(params: RequestParams<TQueryParams, TParams>): Promise<TResponse> {
       return await fetchRequest({ ...params, method: "delete", ...option });
     },
   };

--- a/src/utils/httpRequest.ts
+++ b/src/utils/httpRequest.ts
@@ -5,14 +5,14 @@ const headers: HeadersInit = {
   "Content-Type": "application/json; charset=utf-8",
 };
 
-const fetchRequest = <TQueryParams, TParams>({
+const fetchRequest = <TParams>({
   path,
   method,
   queryParams,
   params,
   isMock,
   shouldAuthorize,
-}: RequestParams<TQueryParams, TParams>) => {
+}: RequestParams<TParams>) => {
   const convertedParams = queryParams
     ? Object.entries(queryParams).reduce((newObj: Record<string, string>, [key, value]) => {
         newObj[key] = value.toString();
@@ -46,19 +46,19 @@ const fetchRequest = <TQueryParams, TParams>({
 
 const handleRequest = (option?: { isMock: true }) => {
   return {
-    get<TQueryParams, TParams, TResponse>(params: RequestParams<TQueryParams, TParams>): Promise<TResponse> {
-      return fetchRequest<TQueryParams, TParams>({ ...params, method: "get", ...option });
+    get<TParams, TResponse>(params: RequestParams<TParams>): Promise<TResponse> {
+      return fetchRequest<TParams>({ ...params, method: "get", ...option });
     },
 
-    post<TQueryParams, TParams, TResponse>(params: RequestParams<TQueryParams, TParams>): Promise<TResponse> {
+    post<TParams, TResponse>(params: RequestParams<TParams>): Promise<TResponse> {
       return fetchRequest({ ...params, method: "post", ...option });
     },
 
-    put<TQueryParams, TParams, TResponse>(params: RequestParams<TQueryParams, TParams>): Promise<TResponse> {
+    put<TParams, TResponse>(params: RequestParams<TParams>): Promise<TResponse> {
       return fetchRequest({ ...params, method: "put", ...option });
     },
 
-    delete<TQueryParams, TParams, TResponse>(params: RequestParams<TQueryParams, TParams>): Promise<TResponse> {
+    delete<TParams, TResponse>(params: RequestParams<TParams>): Promise<TResponse> {
       return fetchRequest({ ...params, method: "delete", ...option });
     },
   };

--- a/src/utils/httpRequest.ts
+++ b/src/utils/httpRequest.ts
@@ -5,7 +5,7 @@ const headers: HeadersInit = {
   "Content-Type": "application/json; charset=utf-8",
 };
 
-const fetchRequest = async <TQueryParams, TParams>({
+const fetchRequest = <TQueryParams, TParams>({
   path,
   method,
   queryParams,
@@ -27,17 +27,17 @@ const fetchRequest = async <TQueryParams, TParams>({
     headers.Authorization = token ? `Bearer ${token}` : "";
   }
 
-  return await fetch(`${isMock ? "" : URL.API}${path}${searchParams ? `?${searchParams}` : ""}`, {
+  return fetch(`${isMock ? "" : URL.API}${path}${searchParams ? `?${searchParams}` : ""}`, {
     headers,
     method,
     body: JSON.stringify(params),
   })
-    .then(async (res) => {
+    .then((res) => {
       if (!res.ok) {
-        return await Promise.reject(res.status);
+        return Promise.reject(res.status);
       }
 
-      return await res.json();
+      return res.json();
     })
     .catch((err) => {
       handleError(err);
@@ -46,20 +46,20 @@ const fetchRequest = async <TQueryParams, TParams>({
 
 const handleRequest = (option?: { isMock: true }) => {
   return {
-    async get<TQueryParams, TParams, TResponse>(params: RequestParams<TQueryParams, TParams>): Promise<TResponse> {
-      return await fetchRequest<TQueryParams, TParams>({ ...params, method: "get", ...option });
+    get<TQueryParams, TParams, TResponse>(params: RequestParams<TQueryParams, TParams>): Promise<TResponse> {
+      return fetchRequest<TQueryParams, TParams>({ ...params, method: "get", ...option });
     },
 
-    async post<TQueryParams, TParams, TResponse>(params: RequestParams<TQueryParams, TParams>): Promise<TResponse> {
-      return await fetchRequest({ ...params, method: "post", ...option });
+    post<TQueryParams, TParams, TResponse>(params: RequestParams<TQueryParams, TParams>): Promise<TResponse> {
+      return fetchRequest({ ...params, method: "post", ...option });
     },
 
-    async put<TQueryParams, TParams, TResponse>(params: RequestParams<TQueryParams, TParams>): Promise<TResponse> {
-      return await fetchRequest({ ...params, method: "put", ...option });
+    put<TQueryParams, TParams, TResponse>(params: RequestParams<TQueryParams, TParams>): Promise<TResponse> {
+      return fetchRequest({ ...params, method: "put", ...option });
     },
 
-    async delete<TQueryParams, TParams, TResponse>(params: RequestParams<TQueryParams, TParams>): Promise<TResponse> {
-      return await fetchRequest({ ...params, method: "delete", ...option });
+    delete<TQueryParams, TParams, TResponse>(params: RequestParams<TQueryParams, TParams>): Promise<TResponse> {
+      return fetchRequest({ ...params, method: "delete", ...option });
     },
   };
 };


### PR DESCRIPTION
### Description
- api request 함수 제네릭 타입 전달되지 않는 부분 수정
  - RequestParams의 제네릭 TQueryParams, TParams 타입 전달

=> TQueryParams, TParams 타입 합쳐 동일하게 지정

### Question
- api 요청마다 queryParams와 params중 하나의 인자만 전달하는 경우, 제네릭 타입을 <TQueryParams, TParams, TResponse> 순으로 전달해주어야 해 전달하지 않는 인자는 null로 지정했습니다. `ex) <null, TParams, TResponse>`
- null로 주는 편이 해당 값을 주지 않는다는 것을 명시하기 좋은 것 같아서 했는데, 이런 방식도 괜찮을까요?