### PR TITLE
Refactor: move createNewCardList to component from onMutate

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -24,6 +24,7 @@
     "no-unused-vars": "error",
     "n/handle-callback-err": "off",
     "no-multiple-empty-lines": "error",
+    "@typescript-eslint/no-confusing-void-expression": "off",
     "@typescript-eslint/no-floating-promises": "off",
     "@typescript-eslint/promise-function-async": "off",
     "@typescript-eslint/consistent-type-imports": "off",

--- a/src/components/Board/createNewCardList.ts
+++ b/src/components/Board/createNewCardList.ts
@@ -1,0 +1,46 @@
+import { ICard, ICardList } from "@/interfaces/cards";
+
+export const createNewCardList = (currentCardList: ICardList[], cardId: string, listId: string, index: number) => {
+  const currentCardsList = currentCardList.find((cardList) => cardList.cards.some((card) => card.id === cardId));
+  const currentListId = currentCardsList?.id;
+  const card = currentCardsList?.cards.find((card) => card.id === cardId);
+  if (!card) return;
+
+  const updatedCardLists = currentCardList.map((cardList) => {
+    const isDroppedList = cardList.id === listId;
+    const isDraggedList = cardList.id === currentListId;
+    const isMovedToSameList = isDroppedList && isDraggedList;
+
+    if (isMovedToSameList) {
+      return reorderCardInList(cardList, card, cardId, index);
+    }
+
+    if (isDroppedList) {
+      return addCardToList(cardList, card, index);
+    }
+
+    if (isDraggedList) {
+      return removeCardFromList(cardList, cardId);
+    }
+
+    return cardList;
+  });
+
+  return updatedCardLists;
+};
+
+const reorderCardInList = (cardList: ICardList, card: ICard, cardId: string, index: number) => {
+  const filteredCardList = removeCardFromList(cardList, cardId);
+  return addCardToList(filteredCardList, card, index);
+};
+
+const addCardToList = (cardList: ICardList, card: ICard, index: number) => {
+  const newCards = Array.from(cardList.cards);
+  newCards.splice(index, 0, card);
+  return { ...cardList, cards: newCards };
+};
+
+const removeCardFromList = (cardList: ICardList, cardId: string) => {
+  const filteredCards = cardList.cards.filter((card) => card.id !== cardId);
+  return { ...cardList, cards: filteredCards };
+};

--- a/src/components/Board/utils/rearrangeCards.ts
+++ b/src/components/Board/utils/rearrangeCards.ts
@@ -1,6 +1,6 @@
 import { ICard, ICardList } from "@/interfaces/cards";
 
-export const createNewCardList = (currentCardList: ICardList[], cardId: string, listId: string, index: number) => {
+export const rearrangeCards = (currentCardList: ICardList[], cardId: string, listId: string, index: number) => {
   const currentCardsList = currentCardList.find((cardList) => cardList.cards.some((card) => card.id === cardId));
   const currentListId = currentCardsList?.id;
   const card = currentCardsList?.cards.find((card) => card.id === cardId);

--- a/src/components/Modals/components/CardDetailModal/index.stories.tsx
+++ b/src/components/Modals/components/CardDetailModal/index.stories.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import loadable from "@loadable/component";
-const Component = loadable(async () => await import("@components/modals/CardDetailModal"));
+const Component = loadable(() => import("@components/modals/components/CardDetailModal"));
 
 export default {
   title: "components/modals/CardDetailModal",

--- a/src/components/Modals/components/InviteToWorkspaceModal/index.stories.tsx
+++ b/src/components/Modals/components/InviteToWorkspaceModal/index.stories.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import loadable from "@loadable/component";
-const InviteToWorkspaceModal = loadable(async () => await import("@components/modals/InviteToWorkspaceModal"));
+const InviteToWorkspaceModal = loadable(() => import("@components/modals/components/InviteToWorkspaceModal"));
 
 export default {
   title: "components/modals/InviteToWorkspaceModal",

--- a/src/components/inputs/Input/index.stories.tsx
+++ b/src/components/inputs/Input/index.stories.tsx
@@ -9,7 +9,7 @@ export default {
 const Template = () => {
   const handleSubmit = () => {};
 
-  return <Component onSubmit={handleSubmit} placeHolder="Enter new keyword..." name="input" />;
+  return <Component onSubmit={handleSubmit} placeHolder="Enter new keyword..." name="input" defaultValue="" />;
 };
 
 export const Input = Template.bind({});

--- a/src/components/inputs/Input/index.tsx
+++ b/src/components/inputs/Input/index.tsx
@@ -5,14 +5,15 @@ import * as S from "./style";
 export interface Props {
   onSubmit: (params: Record<string, string>) => void;
   name: string;
+  defaultValue: string;
   placeHolder: string;
   onChange?: (data: string) => void;
 }
 
-function Input({ placeHolder, name, onSubmit, onChange }: Props) {
+function Input({ placeHolder, name, defaultValue = "", onSubmit, onChange }: Props) {
   const { handleSubmit, control } = useForm({
     defaultValues: {
-      [name]: "",
+      [name]: defaultValue,
     },
     mode: "onChange",
   });

--- a/src/components/menus/FilterMenu/index.tsx
+++ b/src/components/menus/FilterMenu/index.tsx
@@ -1,4 +1,6 @@
 import React from "react";
+import { useSearchParams } from "react-router-dom";
+import { SEARCH_PARAMS_KEY } from "@/constants";
 import Input from "@components/inputs/Input";
 import * as S from "./style";
 
@@ -7,6 +9,9 @@ interface Props {
 }
 
 function FilterMenu({ onClick }: Props) {
+  const [searchParams] = useSearchParams(window.location.search);
+  const searchKeyword = searchParams.get(SEARCH_PARAMS_KEY.SEARCH) ?? "";
+
   const onSubmit = ({ filterMenu }: Record<"filterMenu", string>) => {
     onClick(filterMenu);
   };
@@ -18,7 +23,13 @@ function FilterMenu({ onClick }: Props) {
   return (
     <div>
       <S.Title>Keyword</S.Title>
-      <Input placeHolder="Enter a keyword..." name="filterMenu" onSubmit={onSubmit} onChange={onChange} />
+      <Input
+        placeHolder="Enter a keyword..."
+        name="filterMenu"
+        onSubmit={onSubmit}
+        onChange={onChange}
+        defaultValue={searchKeyword}
+      />
       <S.Description>Search cards, members, labels, and more.</S.Description>
     </div>
   );

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -12,3 +12,7 @@ export const MODAL_TYPE = {
 export const STORAGE_KEY = {
   TOKEN: "token",
 };
+
+export const SEARCH_PARAMS_KEY = {
+  SEARCH: "search",
+};

--- a/src/mocks/handlers/cards.ts
+++ b/src/mocks/handlers/cards.ts
@@ -12,6 +12,7 @@ import {
   editCardPosition,
   getAllCardListsWithCards,
 } from "../dbfunctions";
+import { SEARCH_PARAMS_KEY } from "@/constants";
 
 const checkAuthorization = async (
   req: RestRequest<any, PathParams<string>>,
@@ -25,7 +26,7 @@ const checkAuthorization = async (
 
 export const cardsHandlers = [
   rest.get("/cards", async (req, res, ctx) => {
-    const search = req.url.searchParams.get("search");
+    const search = req.url.searchParams.get(SEARCH_PARAMS_KEY.SEARCH);
     const data = await getAllCardListsWithCards(search ?? "");
     return await res(ctx.delay(), ctx.status(201), ctx.json(data));
   }),

--- a/src/pages/BoardPage/index.tsx
+++ b/src/pages/BoardPage/index.tsx
@@ -1,5 +1,7 @@
 import React, { useState } from "react";
+import { useSearchParams } from "react-router-dom";
 import loadable from "@loadable/component";
+import { SEARCH_PARAMS_KEY } from "@/constants";
 import Sider from "@components/Sider";
 import Drawer from "@components/Drawer";
 import Header from "@components/Header";
@@ -17,10 +19,12 @@ interface BoardProps {
 
 const BoardPage: React.FC = () => {
   const [isOpen, setOpen] = useState(false);
-  const [searchKeyword, setSearchKeywords] = useState<string>("");
+  const [searchParams, setSearchParams] = useSearchParams(window.location.search);
+  const searchKeyword = searchParams.get(SEARCH_PARAMS_KEY.SEARCH) ?? "";
 
   const searchCards = (keyword: string) => {
-    setSearchKeywords(keyword);
+    searchParams.set(SEARCH_PARAMS_KEY.SEARCH, keyword);
+    setSearchParams(searchParams);
   };
 
   const showDrawer = () => {

--- a/src/queries/cards/index.ts
+++ b/src/queries/cards/index.ts
@@ -1,10 +1,11 @@
 import { useSearchParams } from "react-router-dom";
 import { AxiosError } from "axios";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { request } from "@/utils/httpRequest";
-import * as I from "./interface";
-import { ICard, ICardList } from "@/interfaces/cards";
 import { SEARCH_PARAMS_KEY } from "@/constants";
+import { request } from "@/utils/httpRequest";
+import { RequestParams } from "@/interfaces/httpRequest";
+import { ICard, ICardList } from "@/interfaces/cards";
+import * as I from "./interface";
 
 const cardListsKeys = {
   all: ["cardLists"] as const,
@@ -12,14 +13,17 @@ const cardListsKeys = {
 };
 
 export const useCardsQuery = ({ search }: I.GetCardRequest) => {
+  const parameter: RequestParams = {
+    path: "/cards",
+    isMock: true,
+  };
+
+  if (search) parameter.queryParams = { search };
+
   return useQuery(
     cardListsKeys.search(search),
     () => {
-      return request.get<I.GetCardListsResponse[]>({
-        path: "/cards",
-        queryParams: { search },
-        isMock: true,
-      });
+      return request.get<I.GetCardListsResponse[]>(parameter);
     },
     {
       suspense: true,
@@ -114,9 +118,7 @@ export const useEditCardPositionMutation = () => {
         const searchKeyword = searchParams.get(SEARCH_PARAMS_KEY.SEARCH) ?? "";
         queryClient.cancelQueries(cardListsKeys.search(searchKeyword));
 
-        const currentCards = queryClient.getQueryData<ICardList[]>(cardListsKeys.search(searchKeyword), {
-          exact: false,
-        });
+        const currentCards = queryClient.getQueryData<ICardList[]>(cardListsKeys.search(searchKeyword));
         if (!currentCards) return;
 
         const updatedData = createNewCardList(currentCards, cardId, listId, index);

--- a/src/queries/cards/index.ts
+++ b/src/queries/cards/index.ts
@@ -3,8 +3,9 @@ import { AxiosError } from "axios";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { SEARCH_PARAMS_KEY } from "@/constants";
 import { request } from "@/utils/httpRequest";
+import { createNewCardList } from "@components/Board/createNewCardList";
 import { RequestParams } from "@/interfaces/httpRequest";
-import { ICard, ICardList } from "@/interfaces/cards";
+import { ICardList } from "@/interfaces/cards";
 import * as I from "./interface";
 
 const cardListsKeys = {
@@ -131,51 +132,6 @@ export const useEditCardPositionMutation = () => {
       },
     },
   );
-};
-
-const createNewCardList = (currentCardList: ICardList[], cardId: string, listId: string, index: number) => {
-  const currentCardsList = currentCardList.find((cardList) => cardList.cards.some((card) => card.id === cardId));
-  const currentListId = currentCardsList?.id;
-  const card = currentCardsList?.cards.find((card) => card.id === cardId);
-  if (!card) return;
-
-  const updatedCardLists = currentCardList.map((cardList) => {
-    const isDroppedList = cardList.id === listId;
-    const isDraggedList = cardList.id === currentListId;
-    const isMovedToSameList = isDroppedList && isDraggedList;
-
-    if (isMovedToSameList) {
-      return reorderCardInList(cardList, card, cardId, index);
-    }
-
-    if (isDroppedList) {
-      return addCardToList(cardList, card, index);
-    }
-
-    if (isDraggedList) {
-      return removeCardFromList(cardList, cardId);
-    }
-
-    return cardList;
-  });
-
-  return updatedCardLists;
-};
-
-const reorderCardInList = (cardList: ICardList, card: ICard, cardId: string, index: number) => {
-  const filteredCardList = removeCardFromList(cardList, cardId);
-  return addCardToList(filteredCardList, card, index);
-};
-
-const addCardToList = (cardList: ICardList, card: ICard, index: number) => {
-  const newCards = Array.from(cardList.cards);
-  newCards.splice(index, 0, card);
-  return { ...cardList, cards: newCards };
-};
-
-const removeCardFromList = (cardList: ICardList, cardId: string) => {
-  const filteredCards = cardList.cards.filter((card) => card.id !== cardId);
-  return { ...cardList, cards: filteredCards };
 };
 
 export const useDeleteListMutation = () => {

--- a/src/queries/cards/index.ts
+++ b/src/queries/cards/index.ts
@@ -3,7 +3,7 @@ import { AxiosError } from "axios";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { SEARCH_PARAMS_KEY } from "@/constants";
 import { request } from "@/utils/httpRequest";
-import { createNewCardList } from "@components/Board/createNewCardList";
+import { rearrangeCards } from "@components/Board/utils/rearrangeCards";
 import { RequestParams } from "@/interfaces/httpRequest";
 import { ICardList } from "@/interfaces/cards";
 import * as I from "./interface";
@@ -122,7 +122,7 @@ export const useEditCardPositionMutation = () => {
         const currentCards = queryClient.getQueryData<ICardList[]>(cardListsKeys.search(searchKeyword));
         if (!currentCards) return;
 
-        const updatedData = createNewCardList(currentCards, cardId, listId, index);
+        const updatedData = rearrangeCards(currentCards, cardId, listId, index);
         queryClient.setQueryData(cardListsKeys.search(searchKeyword), updatedData);
 
         return { currentCards };


### PR DESCRIPTION
### Description

- onMutate에서 새로운 데이터를 만들기 위한 함수를 utils폴더로 이동
- onMutate 버그 수정: 검색 기능이 추가되면서 검색된 데이터의 데이터를 가져와 optimistic update를 수행하도록 변경
- useSearchParams를 사용해 검색창 defaultValue와 onMutate의 쿼리키 관리
- search 쿼리파라미터 값이 없을 때는 해당 쿼리 파라미터를 포함하지 않고 card데이터 조회 요청을 보내도록 변경

<br>

### Note
- 컴포넌트에서 createNewCardList 함수를 선언한 다음 useEditCardPositionMutation에 넘겨주어 onMutate에서 사용하려고 했는데, 
긴 로직을 Board 컴포넌트 파일에 함께 선언하면 가독성이 많이 떨어지는 것 같아 파일을 분리했습니다. 
그리고 mutation에서 바로 import해 사용했습니다.