### PR TITLE
Add: e2e 테스트 추가

### DIFF
--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -5,5 +5,6 @@ export default defineConfig({
 
   e2e: {
     baseUrl: "http://127.0.0.1:5173/",
+    experimentalStudio: true,
   },
 });

--- a/cypress/e2e/pages/BoardPage.cy.ts
+++ b/cypress/e2e/pages/BoardPage.cy.ts
@@ -2,12 +2,129 @@
 
 import { URL } from "../../../src/constants";
 
-describe("run application", () => {
+describe("Board page 렌더링", () => {
   beforeEach(() => {
-    cy.visit(URL.BASE);
+    cy.visit(`${URL.BASE}board`);
   });
 
-  it("displays Board", () => {
-    cy.get(".sc-beySbM").should("have.text", "Card");
+  it("Header 표시", () => {
+    cy.get(".sc-hAtEyd").should("be.visible");
+  });
+
+  it("Menu 표시", () => {
+    cy.get(".sc-bALXmG").should("be.visible");
+  });
+
+  it("Board 표시", () => {
+    cy.get(".sc-eZYOHW").should("be.visible");
+  });
+
+  it("list1 텍스트를 포함한 카드 목록 렌더링", () => {
+    cy.get(
+      '[data-rbd-droppable-id="list1"] > .sc-oQLfA > .sc-hjsqBZ > [style="padding: 5px 10px 10px; border-radius: 0px 0px 12px 12px; background-color: rgb(234, 236, 240);"] > .sc-ejdXBC > .sc-ldFCYb',
+    ).should("have.text", "list1");
+  });
+
+  it("card1 텍스트를 포함한 카드 렌더링", () => {
+    cy.get('[data-rbd-draggable-id="card1"] > .sc-kiLEMZ > .ant-card > .ant-card-body > p').should(
+      "have.text",
+      "card1",
+    );
+  });
+
+  it("카드, 카드 목록 추가 버튼 렌더링", () => {
+    cy.get(":nth-child(4) > .sc-gUrTyy > .sc-csCMJt").should("have.text", "Add a card");
+    cy.get(".sc-cmEail > form > .sc-gUrTyy > .sc-csCMJt").should("have.text", "Add a list");
+  });
+});
+
+describe("로그인 페이지 리다이렉트 테스트", () => {
+  beforeEach(() => {
+    cy.visit(`${URL.BASE}board`);
+  });
+
+  it("카드 목록 추가 시 로그인 정보 없으면 로그인 페이지로 리다이렉트", function () {
+    cy.get(".sc-cmEail > form > .sc-gUrTyy > .sc-csCMJt").should("have.text", "Add a list");
+    cy.get(".sc-cmEail > form > .sc-gUrTyy > .sc-csCMJt").click();
+    cy.get(".ant-input").should("have.attr", "placeholder", "Enter list title...");
+    cy.get(".sc-kZGvTt > .sc-csCMJt").should("have.text", "Add list");
+    cy.get(".sc-kZGvTt > .anticon > svg").should("be.visible");
+
+    cy.get(".ant-input").type("list3");
+    cy.get(".sc-kZGvTt > .sc-csCMJt").click();
+    cy.location().should((loc) => {
+      expect(loc.pathname).to.eq("/login");
+    });
+    cy.get(".sc-csCMJt").click();
+  });
+});
+
+describe("카드 목록 테스트", () => {
+  beforeEach(() => {
+    cy.visit(`${URL.BASE}board`);
+    localStorage.setItem("token", "testToken");
+  });
+
+  it("카드 목록 추가", function () {
+    cy.get(".sc-cmEail > form > .sc-gUrTyy > .sc-csCMJt").should("have.text", "Add a list");
+    cy.get(".sc-cmEail > form > .sc-gUrTyy > .sc-csCMJt").click();
+    cy.get(".ant-input").should("have.attr", "placeholder", "Enter list title...");
+    cy.get(".sc-kZGvTt > .sc-csCMJt").should("have.text", "Add list");
+    cy.get(".sc-kZGvTt > .anticon > svg").should("be.visible");
+
+    cy.get("form > :nth-child(1) > .ant-input").click();
+    cy.get(".ant-input").type("list3");
+    cy.get(".sc-kZGvTt > .sc-csCMJt").click();
+  });
+
+  it("카드 목록 삭제", () => {
+    cy.visit("http://127.0.0.1:5173/board");
+    cy.get(
+      '[data-rbd-droppable-id="list1"] > .sc-oQLfA > .sc-hjsqBZ > .ant-card-head > .ant-card-head-wrapper > .ant-card-extra',
+    ).click();
+  });
+
+  it("카드 목록 이름 수정", () => {
+    cy.visit("http://127.0.0.1:5173/board");
+    cy.get(
+      '[data-rbd-droppable-id="list1"] > .sc-oQLfA > .sc-hjsqBZ > [style="padding: 5px 10px 10px; border-radius: 0px 0px 12px 12px; background-color: rgb(234, 236, 240);"] > .sc-ejdXBC > .sc-ldFCYb',
+    ).click();
+    cy.get(".ant-input").should("have.value", "list1");
+    cy.get(".ant-input").clear();
+    cy.get(".ant-input").click();
+    cy.get(".ant-input").type("edit list 1{enter}");
+  });
+});
+
+describe("카드 테스트", () => {
+  beforeEach(() => {
+    cy.visit(`${URL.BASE}board`);
+    localStorage.setItem("token", "testToken");
+  });
+
+  it("카드 추가", () => {
+    //인풋 창 토글
+    cy.visit("http://127.0.0.1:5173/board");
+    cy.get(":nth-child(4) > .sc-gUrTyy > .sc-csCMJt").click();
+    cy.get(".sc-kZGvTt > .anticon > svg").click();
+    cy.get(":nth-child(4) > .sc-gUrTyy > .sc-csCMJt").should("have.text", "Add a card");
+
+    //인풋 값 입력 후 제출
+    cy.get(":nth-child(4) > .sc-gUrTyy > .sc-csCMJt").click();
+    cy.get("input").type("card3");
+    cy.get(".sc-kZGvTt > .sc-csCMJt").click();
+  });
+
+  it("카드 수정", () => {
+    cy.get('[data-rbd-draggable-id="card1"] > .sc-kiLEMZ > .ant-card').realHover();
+    cy.get('[data-rbd-draggable-id="card1"] > .sc-kiLEMZ > .ant-card > .ant-card-body > .anticon > svg').click();
+    cy.get(".ant-input").click();
+    cy.get(".sc-dQelHR > .sc-csCMJt").click();
+  });
+
+  it("카드 삭제", () => {
+    cy.get('[data-rbd-draggable-id="card1"] > .sc-kiLEMZ > .ant-card').realHover();
+    cy.get('[data-rbd-draggable-id="card1"] > .sc-kiLEMZ > .ant-card > .ant-card-body > .anticon > svg').click();
+    cy.get(":nth-child(8) > .sc-csCMJt").click();
   });
 });

--- a/cypress/mocks/browser.ts
+++ b/cypress/mocks/browser.ts
@@ -1,0 +1,4 @@
+import { setupWorker } from "msw";
+import handlers from "./handlers";
+
+export const worker = setupWorker(...handlers);

--- a/cypress/mocks/data/cards.ts
+++ b/cypress/mocks/data/cards.ts
@@ -5,11 +5,11 @@ export const mockedCardLists = [
     cards: [
       {
         id: "card1",
-        text: "card1",
+        description: "card1",
       },
       {
         id: "card2",
-        text: "card2",
+        description: "card2",
       },
     ],
   },
@@ -19,7 +19,7 @@ export const mockedCardLists = [
     cards: [
       {
         id: "card2-1",
-        text: "card2-1",
+        description: "card2-1",
       },
     ],
   },

--- a/cypress/mocks/handlers.ts
+++ b/cypress/mocks/handlers.ts
@@ -2,9 +2,8 @@ import { mockedCardLists } from "./data/cards";
 import * as I from "../../src/queries/cards/interface";
 import { DefaultBodyType, PathParams, ResponseComposition, rest, RestContext, RestRequest } from "msw";
 import { v4 as uuidv4 } from "uuid";
-import { SEARCH_PARAMS_KEY } from "../../src/constants";
 
-const checkAuthorization = async (
+const checkAuthorization = (
   req: RestRequest<any, PathParams<string>>,
   res: ResponseComposition<DefaultBodyType>,
   ctx: RestContext,
@@ -15,18 +14,18 @@ const checkAuthorization = async (
 };
 
 export const cardsHandlers = [
-  rest.get("/cards", async (req, res, ctx) => {
-    return await res(ctx.delay(), ctx.status(201), ctx.json(mockedCardLists)); //return mock data
+  rest.get("/cards", (req, res, ctx) => {
+    return res(ctx.delay(), ctx.status(201), ctx.json(mockedCardLists));
   }),
 
-  rest.post<I.AddCardRequest>("/cards", async (req, res, ctx) => {
+  rest.post<I.AddCardRequest>("/cards", (req, res, ctx) => {
     const { description } = req.body;
     const id = uuidv4();
 
-    const isAuthorized = await checkAuthorization(req, res, ctx);
+    const isAuthorized = checkAuthorization(req, res, ctx);
 
     if (!isAuthorized) {
-      return await res(
+      return res(
         ctx.status(401),
         ctx.json({
           message: "access token is required",
@@ -34,7 +33,7 @@ export const cardsHandlers = [
       );
     }
 
-    return await res(
+    return res(
       ctx.delay(),
       ctx.status(201),
       ctx.json({
@@ -45,11 +44,11 @@ export const cardsHandlers = [
     );
   }),
 
-  rest.put<I.EditCardRequest>("/cards", async (req, res, ctx) => {
-    const isAuthorized = await checkAuthorization(req, res, ctx);
+  rest.put<I.EditCardRequest>("/cards", (req, res, ctx) => {
+    const isAuthorized = checkAuthorization(req, res, ctx);
 
     if (!isAuthorized) {
-      return await res(
+      return res(
         ctx.delay(),
         ctx.status(401),
         ctx.json({
@@ -58,7 +57,7 @@ export const cardsHandlers = [
       );
     }
 
-    return await res(
+    return res(
       ctx.status(200),
       ctx.json({
         message: "Card updated",
@@ -66,18 +65,18 @@ export const cardsHandlers = [
     );
   }),
 
-  rest.delete<I.DeleteCardRequest>("/cards", async (req, res, ctx) => {
-    const isAuthorized = await checkAuthorization(req, res, ctx);
+  rest.delete<I.DeleteCardRequest>("/cards", (req, res, ctx) => {
+    const isAuthorized = checkAuthorization(req, res, ctx);
 
     if (!isAuthorized) {
-      return await res(
+      return res(
         ctx.status(401),
         ctx.json({
           message: "access token is required",
         }),
       );
     }
-    return await res(
+    return res(
       ctx.status(200),
       ctx.json({
         message: "Card deleted",
@@ -85,14 +84,14 @@ export const cardsHandlers = [
     );
   }),
 
-  rest.post<I.AddListRequest>("/lists", async (req, res, ctx) => {
+  rest.post<I.AddListRequest>("/lists", (req, res, ctx) => {
     const { title } = req.body as { title: string };
     const id = uuidv4();
 
-    const isAuthorized = await checkAuthorization(req, res, ctx);
+    const isAuthorized = checkAuthorization(req, res, ctx);
 
     if (!isAuthorized) {
-      return await res(
+      return res(
         ctx.status(401),
         ctx.json({
           message: "access token is required",
@@ -100,7 +99,7 @@ export const cardsHandlers = [
       );
     }
 
-    return await res(
+    return res(
       ctx.status(201),
       ctx.json({
         message: "List created",
@@ -110,11 +109,11 @@ export const cardsHandlers = [
     );
   }),
 
-  rest.put<I.EditListRequest>("/lists", async (req, res, ctx) => {
-    const isAuthorized = await checkAuthorization(req, res, ctx);
+  rest.put<I.EditListRequest>("/lists", (req, res, ctx) => {
+    const isAuthorized = checkAuthorization(req, res, ctx);
 
     if (!isAuthorized) {
-      return await res(
+      return res(
         ctx.status(401),
         ctx.json({
           message: "access token is required",
@@ -122,7 +121,7 @@ export const cardsHandlers = [
       );
     }
 
-    return await res(
+    return res(
       ctx.status(200),
       ctx.json({
         message: "List updated",
@@ -130,10 +129,10 @@ export const cardsHandlers = [
     );
   }),
 
-  rest.put<I.EditCardPositionRequest>("/cards/:cardId/move", async (req, res, ctx) => {
-    const isAuthorized = await checkAuthorization(req, res, ctx);
+  rest.put<I.EditCardPositionRequest>("/cards/:cardId/move", (req, res, ctx) => {
+    const isAuthorized = checkAuthorization(req, res, ctx);
     if (!isAuthorized) {
-      return await res(
+      return res(
         ctx.status(401),
         ctx.json({
           message: "access token is required",
@@ -141,7 +140,7 @@ export const cardsHandlers = [
       );
     }
 
-    return await res(
+    return res(
       ctx.status(200),
       ctx.json({
         message: "Card position updated",
@@ -149,11 +148,11 @@ export const cardsHandlers = [
     );
   }),
 
-  rest.delete<I.DeleteListRequest>("/lists", async (req, res, ctx) => {
-    const isAuthorized = await checkAuthorization(req, res, ctx);
+  rest.delete<I.DeleteListRequest>("/lists", (req, res, ctx) => {
+    const isAuthorized = checkAuthorization(req, res, ctx);
 
     if (!isAuthorized) {
-      return await res(
+      return res(
         ctx.status(401),
         ctx.json({
           message: "access token is required",
@@ -161,7 +160,7 @@ export const cardsHandlers = [
       );
     }
 
-    return await res(
+    return res(
       ctx.status(200),
       ctx.json({
         message: "List deleted",

--- a/cypress/mocks/handlers.ts
+++ b/cypress/mocks/handlers.ts
@@ -1,0 +1,173 @@
+import { mockedCardLists } from "./data/cards";
+import * as I from "../../src/queries/cards/interface";
+import { DefaultBodyType, PathParams, ResponseComposition, rest, RestContext, RestRequest } from "msw";
+import { v4 as uuidv4 } from "uuid";
+import { SEARCH_PARAMS_KEY } from "../../src/constants";
+
+const checkAuthorization = async (
+  req: RestRequest<any, PathParams<string>>,
+  res: ResponseComposition<DefaultBodyType>,
+  ctx: RestContext,
+) => {
+  const authToken = req.headers.get("Authorization");
+
+  return !!authToken;
+};
+
+export const cardsHandlers = [
+  rest.get("/cards", async (req, res, ctx) => {
+    return await res(ctx.delay(), ctx.status(201), ctx.json(mockedCardLists)); //return mock data
+  }),
+
+  rest.post<I.AddCardRequest>("/cards", async (req, res, ctx) => {
+    const { description } = req.body;
+    const id = uuidv4();
+
+    const isAuthorized = await checkAuthorization(req, res, ctx);
+
+    if (!isAuthorized) {
+      return await res(
+        ctx.status(401),
+        ctx.json({
+          message: "access token is required",
+        }),
+      );
+    }
+
+    return await res(
+      ctx.delay(),
+      ctx.status(201),
+      ctx.json({
+        message: "Card created",
+        id,
+        description,
+      }),
+    );
+  }),
+
+  rest.put<I.EditCardRequest>("/cards", async (req, res, ctx) => {
+    const isAuthorized = await checkAuthorization(req, res, ctx);
+
+    if (!isAuthorized) {
+      return await res(
+        ctx.delay(),
+        ctx.status(401),
+        ctx.json({
+          message: "access token is required",
+        }),
+      );
+    }
+
+    return await res(
+      ctx.status(200),
+      ctx.json({
+        message: "Card updated",
+      }),
+    );
+  }),
+
+  rest.delete<I.DeleteCardRequest>("/cards", async (req, res, ctx) => {
+    const isAuthorized = await checkAuthorization(req, res, ctx);
+
+    if (!isAuthorized) {
+      return await res(
+        ctx.status(401),
+        ctx.json({
+          message: "access token is required",
+        }),
+      );
+    }
+    return await res(
+      ctx.status(200),
+      ctx.json({
+        message: "Card deleted",
+      }),
+    );
+  }),
+
+  rest.post<I.AddListRequest>("/lists", async (req, res, ctx) => {
+    const { title } = req.body as { title: string };
+    const id = uuidv4();
+
+    const isAuthorized = await checkAuthorization(req, res, ctx);
+
+    if (!isAuthorized) {
+      return await res(
+        ctx.status(401),
+        ctx.json({
+          message: "access token is required",
+        }),
+      );
+    }
+
+    return await res(
+      ctx.status(201),
+      ctx.json({
+        message: "List created",
+        title,
+        id,
+      }),
+    );
+  }),
+
+  rest.put<I.EditListRequest>("/lists", async (req, res, ctx) => {
+    const isAuthorized = await checkAuthorization(req, res, ctx);
+
+    if (!isAuthorized) {
+      return await res(
+        ctx.status(401),
+        ctx.json({
+          message: "access token is required",
+        }),
+      );
+    }
+
+    return await res(
+      ctx.status(200),
+      ctx.json({
+        message: "List updated",
+      }),
+    );
+  }),
+
+  rest.put<I.EditCardPositionRequest>("/cards/:cardId/move", async (req, res, ctx) => {
+    const isAuthorized = await checkAuthorization(req, res, ctx);
+    if (!isAuthorized) {
+      return await res(
+        ctx.status(401),
+        ctx.json({
+          message: "access token is required",
+        }),
+      );
+    }
+
+    return await res(
+      ctx.status(200),
+      ctx.json({
+        message: "Card position updated",
+      }),
+    );
+  }),
+
+  rest.delete<I.DeleteListRequest>("/lists", async (req, res, ctx) => {
+    const isAuthorized = await checkAuthorization(req, res, ctx);
+
+    if (!isAuthorized) {
+      return await res(
+        ctx.status(401),
+        ctx.json({
+          message: "access token is required",
+        }),
+      );
+    }
+
+    return await res(
+      ctx.status(200),
+      ctx.json({
+        message: "List deleted",
+      }),
+    );
+  }),
+];
+
+export default cardsHandlers;

--- a/cypress/support/e2e.ts
+++ b/cypress/support/e2e.ts
@@ -1,0 +1,3 @@
+import "cypress-real-events";
+import { worker } from "../mocks/browser";
+worker.start();

--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
     "@vitejs/plugin-react": "^3.1.0",
     "antd": "^5.4.7",
     "axios": "^1.3.4",
+    "cypress-real-events": "^1.8.1",
     "idb": "^7.1.1",
     "react-beautiful-dnd": "^13.1.1",
     "react-error-boundary": "^4.0.3",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,7 +6,7 @@
       "@utils/*": ["src/utils/*"],
       "@/*": ["src/*"]
     },
-    "types": ["node", "cypress"],
+    "types": ["node", "cypress", "cypress-real-events"],
     "target": "ESNext",
     "useDefineForClassFields": true,
     "lib": ["DOM", "DOM.Iterable", "ESNext"],

--- a/yarn.lock
+++ b/yarn.lock
@@ -8375,6 +8375,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"cypress-real-events@npm:^1.8.1":
+  version: 1.8.1
+  resolution: "cypress-real-events@npm:1.8.1"
+  peerDependencies:
+    cypress: ^4.x || ^5.x || ^6.x || ^7.x || ^8.x || ^9.x || ^10.x || ^11.x || ^12.x
+  checksum: 48f229335f26f8c225428563e94ca091ab7a00e943a4c953e062135b1d37672edec9cb7667452d894b43528b52924cd1b6061df044ccb0665b9c0965a0fe214f
+  languageName: node
+  linkType: hard
+
 "cypress@npm:^12.7.0":
   version: 12.10.0
   resolution: "cypress@npm:12.10.0"
@@ -18584,6 +18593,7 @@ __metadata:
     chromatic: ^6.17.2
     cypress: ^12.7.0
     cypress-react-selector: ^3.0.0
+    cypress-real-events: ^1.8.1
     eslint: ^8.0.1
     eslint-config-prettier: ^8.8.0
     eslint-config-standard-with-typescript: latest


### PR DESCRIPTION
### Description

e2e 테스트 코드 작성
- 카드 목록/ 카드 추가,수정,삭제 
- Board페이지 각 영역 렌더링
- 로그인 페이지 리다이렉트

### Question
- 드래그앤 드랍 테스트: cypress-drag-drop plugin을 사용해보려고 했는데 의도한 대로 테스트가 동작하지는 않는 것 같아 더 찾아보는 중입니다.
- indexed db에 저장하는 로직을 제외한 handler를 따로 만들어서 테스트에 사용했는데, 각 버튼 클릭 등의 이벤트 이후 변경되는 내용이나 msw요청을 가로챌 수 없어 post요청이 보내졌는지를 테스트할 수 없는 문제가 있습니다.  (ex)인풋값 입력 => 제출 버튼 클릭 까지만 테스트)
  - 한편으로는 프론트엔드의 개발 영역을 테스트하는게 목적이니 요청이 성공했는지까지 테스트할 필요가 없을 것 같기도 한데.. 이 범위까지만 테스트해도 충분할까요?